### PR TITLE
Add remotes to description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,3 +21,4 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
 RdMacros: lifecycle
+Remotes: wfmackey/absmapsdata


### PR DESCRIPTION
Extremely minor thing: this just tells devtools where to find absmapsdata when you install abscorr