### PR TITLE
Fix duplication in documentation reference

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -36,5 +36,5 @@ reference:
     desc: >
       Functions for retrieving ABS data
     contents:
-      - seifa_scores
+      - get_seifa
       - get_seifa_index_sheet


### PR DESCRIPTION
Currently `anzsco`, `anzsic`, `asced_foe`, and `asced_foe` are duplicated under the "Importing ABS Data" section of the package reference due to an error in the pkgdown configuration which this PR fixes.